### PR TITLE
Fix Broken Port Parsing Logic in 1.0.2

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -191,7 +191,7 @@ func validateCIDRList(cidrs string) error {
 func validatePortList(ports string) error {
 	if len(ports) > 0 {
 		for _, port := range strings.Split(ports, ",") {
-			if _, err := strconv.ParseInt(port, 10, 16); err != nil {
+			if _, err := strconv.ParseUint(strings.TrimSpace(port), 10, 16); err != nil {
 				return fmt.Errorf("failed parsing port '%s': %v", port, err)
 			}
 		}


### PR DESCRIPTION
Fix taken from upstream 1.0.3. The existing logic in 1.0.2 breaks for 5+ digit ports.